### PR TITLE
Add Algolia PHP support version 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 

--- a/composer.json
+++ b/composer.json
@@ -16,24 +16,24 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
-        "algolia/algoliasearch-client-php": "^1.27",
-        "graham-campbell/manager": "^4.0",
+        "php": "^7.2",
+        "algolia/algoliasearch-client-php": "^2.0",
+        "graham-campbell/manager": "^4.1",
         "illuminate/contracts": "5.7.*",
         "illuminate/support": "5.7.*"
     },
     "require-dev": {
-        "graham-campbell/analyzer": "^2.0",
-        "graham-campbell/testbench": "^5.0",
+        "graham-campbell/analyzer": "^2.1",
+        "graham-campbell/testbench": "^5.1",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.4"
     },
     "config": {
         "preferred-install": "dist"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.1-dev"
+            "dev-master": "4.0-dev"
         },
         "laravel": {
             "providers": [

--- a/src/AlgoliaFactory.php
+++ b/src/AlgoliaFactory.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Vinkla\Algolia;
 
-use AlgoliaSearch\Client;
+use Algolia\AlgoliaSearch\SearchClient;
 use InvalidArgumentException;
 
 /**
@@ -28,9 +28,9 @@ class AlgoliaFactory
      *
      * @param array $config
      *
-     * @return \AlgoliaSearch\Client
+     * @return \Algolia\AlgoliaSearch\SearchClient
      */
-    public function make(array $config): Client
+    public function make(array $config): SearchClient
     {
         $config = $this->getConfig($config);
 
@@ -64,11 +64,11 @@ class AlgoliaFactory
      *
      * @param array $auth
      *
-     * @return \AlgoliaSearch\Client
+     * @return \Algolia\AlgoliaSearch\SearchClient
      */
-    protected function getClient(array $auth): Client
+    protected function getClient(array $auth): SearchClient
     {
-        return new Client(
+        return SearchClient::create(
             $auth['id'],
             $auth['key']
         );

--- a/src/AlgoliaManager.php
+++ b/src/AlgoliaManager.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Vinkla\Algolia;
 
-use AlgoliaSearch\Client;
+use Algolia\AlgoliaSearch\SearchClient;
 use GrahamCampbell\Manager\AbstractManager;
 use Illuminate\Contracts\Config\Repository;
 
@@ -51,9 +51,9 @@ class AlgoliaManager extends AbstractManager
      *
      * @param array $config
      *
-     * @return \AlgoliaSearch\Client
+     * @return \Algolia\AlgoliaSearch\SearchClient
      */
-    protected function createConnection(array $config): Client
+    protected function createConnection(array $config): SearchClient
     {
         return $this->factory->make($config);
     }

--- a/src/AlgoliaServiceProvider.php
+++ b/src/AlgoliaServiceProvider.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Vinkla\Algolia;
 
-use AlgoliaSearch\Client;
+use Algolia\AlgoliaSearch\SearchClient;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider;
@@ -110,7 +110,7 @@ class AlgoliaServiceProvider extends ServiceProvider
             return $manager->connection();
         });
 
-        $this->app->alias('algolia.connection', Client::class);
+        $this->app->alias('algolia.connection', SearchClient::class);
     }
 
     /**

--- a/tests/AlgoliaFactoryTest.php
+++ b/tests/AlgoliaFactoryTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Vinkla\Tests\Algolia;
 
-use AlgoliaSearch\Client;
+use Algolia\AlgoliaSearch\SearchClient;
 use Vinkla\Algolia\AlgoliaFactory;
 
 /**
@@ -32,7 +32,7 @@ class AlgoliaFactoryTest extends AbstractTestCase
             'key' => 'your-api-key',
         ]);
 
-        $this->assertInstanceOf(Client::class, $return);
+        $this->assertInstanceOf(SearchClient::class, $return);
     }
 
     /**

--- a/tests/AlgoliaManagerTest.php
+++ b/tests/AlgoliaManagerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Vinkla\Tests\Algolia;
 
-use AlgoliaSearch\Client;
+use Algolia\AlgoliaSearch\SearchClient;
 use GrahamCampbell\TestBench\AbstractTestCase as AbstractTestBenchTestCase;
 use Illuminate\Contracts\Config\Repository;
 use Mockery;
@@ -40,7 +40,7 @@ class AlgoliaManagerTest extends AbstractTestBenchTestCase
 
         $return = $manager->connection();
 
-        $this->assertInstanceOf(Client::class, $return);
+        $this->assertInstanceOf(SearchClient::class, $return);
 
         $this->assertArrayHasKey('algolia', $manager->getConnections());
     }
@@ -58,7 +58,7 @@ class AlgoliaManagerTest extends AbstractTestBenchTestCase
         $config['name'] = 'algolia';
 
         $manager->getFactory()->shouldReceive('make')->once()
-            ->with($config)->andReturn(Mockery::mock(Client::class));
+            ->with($config)->andReturn(Mockery::mock(SearchClient::class));
 
         return $manager;
     }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Vinkla\Tests\Algolia;
 
-use AlgoliaSearch\Client;
+use Algolia\AlgoliaSearch\SearchClient;
 use GrahamCampbell\TestBenchCore\ServiceProviderTrait;
 use Vinkla\Algolia\AlgoliaFactory;
 use Vinkla\Algolia\AlgoliaManager;
@@ -39,7 +39,7 @@ class ServiceProviderTest extends AbstractTestCase
 
     public function testBindings()
     {
-        $this->assertIsInjectable(Client::class);
+        $this->assertIsInjectable(SearchClient::class);
 
         $original = $this->app['algolia.connection'];
         $this->app['algolia']->reconnect();


### PR DESCRIPTION
This pull request adds support for `algolia/algoliasearch-client-php` [new version](https://github.com/algolia/algoliasearch-client-php/releases/tag/2.0.0-RC).